### PR TITLE
* queries/type-usage.sql: fix typo

### DIFF
--- a/queries/type-usage.sql
+++ b/queries/type-usage.sql
@@ -4,7 +4,7 @@ SELECT
   COUNT(*) count
 FROM (
   SELECT
-    REGEXP_EXTRACT(line, r'(augeus|computer|cron|exec|file|filebucket|group|host|interface|k5login|macauthorization|mailalias|maillist|mcx|mount|notify|package|resources|router|schedule|scheduled_task|selboolean|selmodule|service|ssh_authorized_key|sshkey|stage|tidy|user|vlan|yumrepo|zfs|zone|zpool)\s?{') type,
+    REGEXP_EXTRACT(line, r'(augeas|computer|cron|exec|file|filebucket|group|host|interface|k5login|macauthorization|mailalias|maillist|mcx|mount|notify|package|resources|router|schedule|scheduled_task|selboolean|selmodule|service|ssh_authorized_key|sshkey|stage|tidy|user|vlan|yumrepo|zfs|zone|zpool)\s?{') type,
     id
   FROM (
     SELECT


### PR DESCRIPTION
Fixes a typo (`augeus` -> `augeas`). Sadly, I can't seem to run the query myself - looks like I am missing permissions on the dataset. Would love to see what the updated output looks like.